### PR TITLE
Adding authenticate method

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -7,3 +7,6 @@ jspm_packages
 
 # Webpack directories
 .webpack
+
+# Credentials folder
+credentials

--- a/server/mockData/mockInfo.json
+++ b/server/mockData/mockInfo.json
@@ -6,7 +6,7 @@
       "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
       "Accept-Encoding": "gzip, deflate, br",
       "Accept-Language": "en-GB,en-US;q=0.8,en;q=0.6,zh-CN;q=0.4",
-      "Authorization": "JWT teste",
+      "Authorization": "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3QiLCJwYXNzd29yZCI6InRlc3QiLCJpYXQiOjE2MDQzMTQxNjIsImV4cCI6MTYwNTE3ODE2Mn0.p8C8YBYjRxbVqWaf6WFXOKaRTQQtZGb3u-5a4C27M9s",
       "cache-control": "max-age=0",
       "CloudFront-Forwarded-Proto": "https",
       "CloudFront-Is-Desktop-Viewer": "true",
@@ -55,15 +55,8 @@
       "apiId": "j3azlsj0c4"
     },
     "body": { 
-        "countryCode": "GBR",
-        "name": "Netflix 20% off subscription",
-        "publisherId": "4be33e07-69c2-42ac-83b9-96cbb28a47c3",
-        "brandId": "86a568ff-4d6b-4559-8c0e-a4a0586b8e85",
-        "startDate": "2020-04-25T00:00:00",
-        "type": {
-          "name": "discount",
-          "value": 20
-        }
+        "username": "test",
+        "password": "test"
     },
     "isBase64Encoded": false
   }

--- a/server/serverless.ts
+++ b/server/serverless.ts
@@ -37,6 +37,28 @@ const serverlessConfiguration: Serverless = {
           }
         }
       ]
+    },
+    verifyToken: {
+      handler: 'src/handlers/auth.checkAuthentication',
+      events: [
+        {
+          http: {
+            method: 'get',
+            path: 'auth/verify'
+          }
+        }
+      ]
+    },
+    authenticate: {
+      handler: 'src/handlers/auth.authenticate',
+      events: [
+        {
+          http: {
+            method: 'post',
+            path: 'auth/verify'
+          }
+        }
+      ]
     }
   }
 }

--- a/server/src/controllers/auth.ts
+++ b/server/src/controllers/auth.ts
@@ -1,0 +1,41 @@
+import { APIGatewayProxyEvent } from "aws-lambda"
+import { Context } from "vm"
+import { authenticate } from "../models/auth"
+import { checkToken, extractTokenFromHeaders } from "../utils/auth"
+import { parseBody } from "../utils/lambdaUtils"
+import { BadRequest, InternalServerError, OK } from "../utils/lambdaWrapper"
+
+class Auth {
+  public verify(event: APIGatewayProxyEvent, _context: Context) {
+    try {
+      const token = extractTokenFromHeaders(event)
+      const decoded = checkToken(token)
+      if (!decoded || !token) {
+        return BadRequest({ message: 'Invalid or missing token' })
+      }
+      return OK({
+        appName: 'Darkmoon Cloud',
+        token: decoded
+      })
+    } catch (e) {
+      return InternalServerError({ message: e })
+    }
+  }
+
+  public async authenticate(event: APIGatewayProxyEvent, _context: Context) {
+    try {
+      const body = parseBody(event.body)
+      const { username, password } = body
+      if (!username || !password) {
+        return BadRequest({ message: 'Missing credentials' })
+      }
+      const signed = await authenticate(username, password)
+      return OK(signed)
+    } catch (e) {
+      return InternalServerError({ message: e })
+    }
+  }
+}
+
+const handler = new Auth()
+export default handler

--- a/server/src/controllers/info.ts
+++ b/server/src/controllers/info.ts
@@ -1,10 +1,9 @@
 import { APIGatewayProxyEvent, Context } from "aws-lambda";
-import { PrivateLambda } from "../handlers/auth";
 import { InternalServerError, OK } from "../utils/lambdaWrapper";
 
 class Info {
 
-  public getInfo(event: APIGatewayProxyEvent, context: Context) {
+  public getInfo(_event: APIGatewayProxyEvent, _context: Context) {
     try {
       return OK({
         appName: 'Darkmoon Cloud'

--- a/server/src/handlers/auth.ts
+++ b/server/src/handlers/auth.ts
@@ -1,57 +1,10 @@
-import * as jwt from 'jsonwebtoken'
-import { Unauthorized } from '../utils/lambdaWrapper'
+import { APIGatewayProxyHandler } from "aws-lambda"
+import authHandler from '../controllers/auth'
 
-const testPrivateKey = "banaan"
-
-const extractToken = (args) => {
-  const functionArgs = args && args[0]
-  if (!functionArgs) {
-    return null
-  }
-
-  const headers = functionArgs && functionArgs.headers
-  if (!headers) {
-    return null
-  }
-
-  const authorization = headers && (headers.Authorization || headers.authorization)
-  if (!authorization) {
-    return null
-  }
-
-  return authorization.replace('JWT', '').replace(' ', '')
+export const checkAuthentication: APIGatewayProxyHandler = async (event, context) => {
+  return authHandler.verify(event, context)
 }
 
-const checkToken = (token: string) => {
-  try {
-    const decodedToken = jwt.verify(token, testPrivateKey)
-    return decodedToken
-  } catch (e) {
-    console.error(`Failed to verify token: ${e.message}`)
-    return null
-  }
+export const authenticate: APIGatewayProxyHandler = async (event, context) => {
+  return authHandler.authenticate(event, context)
 }
-
-/**
- * Decorator that overrides the lambdas
- * and kicks the request out if no or invalid
- * authorization was provided
- */
-export const PrivateLambda = () => {
-  return (_target: Object, _key: string | symbol, descriptor: PropertyDescriptor) => {
-    const original = descriptor.value
-    descriptor.value = (...args) => {
-      const authorization = extractToken(args)
-      if (!authorization) {
-        return Unauthorized('Missing authorization token')
-      }
-
-      const decoded = checkToken(authorization)
-      if (!decoded) {
-        return Unauthorized('Invalid token provided')
-      }
-
-      return original.apply(this, args)
-    }
-  }
-} 

--- a/server/src/models/auth.ts
+++ b/server/src/models/auth.ts
@@ -1,0 +1,14 @@
+import { AuthPayload } from '../typings/auth'
+import { encodePayload } from '../utils/auth'
+
+export const authenticate = async (username: string, _password: string): Promise<AuthPayload> => {
+    const encoded = encodePayload({
+        username
+    })
+    return {
+        token: encoded,
+        user: {
+            name: username
+        }
+    }
+}

--- a/server/src/typings/auth.ts
+++ b/server/src/typings/auth.ts
@@ -1,0 +1,8 @@
+export type AuthUser = {
+    name: string
+}
+
+export type AuthPayload = {
+    token: string,
+    user?: AuthUser
+}

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -1,0 +1,65 @@
+import * as jwt from 'jsonwebtoken'
+import { Unauthorized } from './lambdaWrapper'
+
+const privateKey = "1c617b94-5929-42d5-a423-e0e812141162"
+
+export const extractTokenFromHeaders = (event: any) => {
+  const headers = event && event.headers
+  if (!headers) {
+    return null
+  }
+
+  const authorization = headers && (headers.Authorization || headers.authorization)
+  if (!authorization) {
+    return null
+  }
+
+  return authorization.replace('JWT', '').replace(' ', '')
+}
+
+const extractToken = (args) => {
+  const functionArgs = args && args[0]
+  if (!functionArgs) {
+    return null
+  }
+
+  return extractTokenFromHeaders(functionArgs)
+}
+
+export const checkToken = (token: string) => {
+  try {
+    const decodedToken = jwt.verify(token, privateKey)
+    return decodedToken
+  } catch (e) {
+    console.error(`Failed to verify token: ${e.message}`)
+    return null
+  }
+}
+
+export const encodePayload = (payload: any) => {
+  return jwt.sign(payload, privateKey, { expiresIn: '10d' })
+}
+
+/**
+ * Decorator that overrides the lambdas
+ * and kicks the request out if no or invalid
+ * authorization was provided
+ */
+export const PrivateLambda = () => {
+  return (_target: Object, _key: string | symbol, descriptor: PropertyDescriptor) => {
+    const original = descriptor.value
+    descriptor.value = (...args) => {
+      const authorization = extractToken(args)
+      if (!authorization) {
+        return Unauthorized('Missing authorization token')
+      }
+
+      const decoded = checkToken(authorization)
+      if (!decoded) {
+        return Unauthorized('Invalid token provided')
+      }
+
+      return original.apply(this, args)
+    }
+  }
+} 

--- a/server/src/utils/lambdaUtils.ts
+++ b/server/src/utils/lambdaUtils.ts
@@ -1,0 +1,3 @@
+export const parseBody = (body: any) => {
+    return typeof(body) === 'string' ? JSON.parse(body) : body
+}

--- a/server/src/utils/lambdaWrapper.ts
+++ b/server/src/utils/lambdaWrapper.ts
@@ -25,3 +25,7 @@ export const Unauthorized = (reason: string): APIGatewayProxyResult => {
 export const InternalServerError = (body?: any, headers?: any): APIGatewayProxyResult => {
   return buildResponse(500, body, headers)
 }
+
+export const BadRequest = (body?: any, headers?: any): APIGatewayProxyResult => {
+  return buildResponse(400, body, headers)
+}


### PR DESCRIPTION
This pull request adds the /auth/verify POST endpoint.

Although it still does not do anything besides signing a random payload and returning a JWT token, it will unblock us from developing other features that require a token in the header.